### PR TITLE
Category Support

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ function refresh(){
     })
 }
 
+
 // ~~~~~~~~~~~ Endpoint requests ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // When a request is made to root
@@ -39,10 +40,12 @@ app.get('/', function (req, res) {
 	res.send('Welcome to the Factfulnews API!') 
 })
 
+
+// ~~~~~~~~~~~ Endpoint requests for each category ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 // Request to /all
 // Returns a JSON array of articles on success, otherwise undefined on error
 app.get('/all', function (req, res, next) {
-    // This should just send the articles
     store.load('all', function(err, articleObj){
     	if (err) {
     		next(err)
@@ -56,6 +59,44 @@ app.get('/all', function (req, res, next) {
         res.send(JSON.stringify({"articles": articleObj.articles}))
     })
 })
+
+// Request to /business
+app.get('/business', function (req, res, next) {
+	res.send('Business articles will come in here!') 
+})
+
+// Request to /entertainment
+app.get('/entertainment', function (req, res, next) {
+	res.send('Entertainment articles will come in here!') 
+})
+
+// Request to /general
+app.get('/general', function (req, res, next) {
+	res.send('General articles will come in here!') 
+})
+
+// Request to /health
+app.get('/health', function (req, res, next) {
+	res.send('Health articles will come in here!') 
+})
+
+// Request to /science
+app.get('/science', function (req, res, next) {
+	res.send('Science articles will come in here!') 
+})
+
+// Request to /sports
+app.get('/sports', function (req, res, next) {
+	res.send('Sports articles will come in here!') 
+})
+
+// Request to /technology
+app.get('/technology', function (req, res, next) {
+	res.send('Technology articles will come in here!') 
+})
+
+
+// ~~~~~~~~~~~ Endpoint requests for each category's articles ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // Request to /all/article
 // Returns a string with HTML of the article body or URL to the article on error.
@@ -74,6 +115,7 @@ app.get('/all/article', function (req, res, next) {
 
     })
 })
+
 
 // ~~~~~~~~~~~ Startup the backend and repeat every midnight ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const annotateArticles = require("./lib/annotate.js")
 
 // Constants
 const LOCAL_PORT = 3000 // If this is being run locally then do it on this port
-var categoryList = ['all', 'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology']
+const categoryList = ['all', 'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology']
 
 function refreshAll() {
 	for (var i = 0; i < categoryList.length; i++){

--- a/app.js
+++ b/app.js
@@ -12,16 +12,23 @@ const annotateArticles = require("./lib/annotate.js")
 
 // Constants
 const LOCAL_PORT = 3000 // If this is being run locally then do it on this port
+var categoryList = ['all', 'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology']
+
+function refreshAll() {
+	for (var i = 0; i < categoryList.length; i++){
+		refresh(categoryList[i])
+	}
+}
 
 // Prepares all the annotated articles for viewing
-function refresh(){
-    fetchAllArticles(store, status => {
+function refresh(category){
+    fetchAllArticles(store, category, status => {
         console.log("Fetching complete. " + (status.success ? "Success." : "Failure."))
     	if (status.success)
-		    prepArticles(store, status => {
+		    prepArticles(store, category, status => {
             console.log("Prepping complete. " + (status.success ? "Success." : "Failure."))
 		    	if (status.success)
-				    selectArticles(store, status => {
+				    selectArticles(store, category, status => {
                         console.log("Selecting complete. " + (status.success ? "Success." : "Failure."))
 
 				    	if (status.success)
@@ -41,89 +48,57 @@ app.get('/', function (req, res) {
 })
 
 
-// ~~~~~~~~~~~ Endpoint requests for each category ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-// Request to /all
 // Returns a JSON array of articles on success, otherwise undefined on error
-app.get('/all', function (req, res, next) {
-    store.load('all', function(err, articleObj){
-    	if (err) {
-    		next(err)
-        	console.log("Error when reading JSON during endpoint call in /all")
-       	}
+app.get('/:category', function (req, res, next) {
+	category = req.params.category
+	if (categoryList.includes(category)){
+		store.load(category, function(err, articleObj){
+			if (err) {
+				next(err)
+				console.log("Error when reading JSON")
+			}
 
-       	for (let i = 0; i < articleObj.articles.length; i++) {
-       		articleObj.articles[i].text = undefined
-       	}
+			for (let i = 0; i < articleObj.articles.length; i++) {
+				articleObj.articles[i].text = undefined
+			}
 
-        res.send(JSON.stringify({"articles": articleObj.articles}))
-    })
-})
-
-// Request to /business
-app.get('/business', function (req, res, next) {
-	res.send('Business articles will come in here!') 
-})
-
-// Request to /entertainment
-app.get('/entertainment', function (req, res, next) {
-	res.send('Entertainment articles will come in here!') 
-})
-
-// Request to /general
-app.get('/general', function (req, res, next) {
-	res.send('General articles will come in here!') 
-})
-
-// Request to /health
-app.get('/health', function (req, res, next) {
-	res.send('Health articles will come in here!') 
-})
-
-// Request to /science
-app.get('/science', function (req, res, next) {
-	res.send('Science articles will come in here!') 
-})
-
-// Request to /sports
-app.get('/sports', function (req, res, next) {
-	res.send('Sports articles will come in here!') 
-})
-
-// Request to /technology
-app.get('/technology', function (req, res, next) {
-	res.send('Technology articles will come in here!') 
+			res.send(JSON.stringify({"articles": articleObj.articles}))
+		})
+	}
+	else {
+		res.send(category + " is not one of the approved categories.")
+	}
 })
 
 
-// ~~~~~~~~~~~ Endpoint requests for each category's articles ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-// Request to /all/article
 // Returns a string with HTML of the article body or URL to the article on error.
-app.get('/all/article', function (req, res, next) {
-	// Retrieve the specific article asked for in the link
-    // GET /all/article?id=<articleID>
+app.get('/:category/article', function (req, res, next) {
+	
     let articleID = req.query.id
+	category = req.params.category
+	if (categoryList.includes(category)){
+		store.load(category, function(err, articleObj) {
+			if (err) {
+				next(err)
+				console.log("Error when reading JSON")
+			}
 
-    store.load('all', function(err, articleObj) {
-        if (err) {
-        	next(err)
-        	console.log("Error when reading JSON during endpoint call in /all/article")
-       	}
-
-        res.send(JSON.stringify(articleObj.articles[articleID]))
-
-    })
+			res.send(JSON.stringify(articleObj.articles[articleID]))
+		})
+	}
+	else {
+		res.send(category + " is not one of the approved categories.")
+	}
 })
 
 
 // ~~~~~~~~~~~ Startup the backend and repeat every midnight ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // Pipeline for getting the annotated articles
-refresh() 
+refreshAll() 
 cron.schedule('0 0 * * *', () => {
     console.log('Crom job refreshing articles at midnight');
-    refresh() 
+    refreshAll()  
 }, {
 	scheduled: true,
 	timezone: 'America/Regina'

--- a/lib/fetchAll.js
+++ b/lib/fetchAll.js
@@ -11,7 +11,7 @@ function fetchAll(store, category, callback){
     newsapi.v2.topHeadlines({
         language: 'en',
         country: 'us',
-        category: ((category=='all')? undefined: category)
+        category: ((category === 'all')? undefined: category)
     })
     .then(response => {
         let articleList = {

--- a/lib/fetchAll.js
+++ b/lib/fetchAll.js
@@ -3,18 +3,19 @@ const newsAPIKey = process.env.NEWS_API     // A file stored locally (or in Hero
 const newsapi = new NewsAPI(newsAPIKey);
 
 // Calls the NewsAPI and gets the articles
-function fetchAll(store, callback){
-    store.remove('all', function(err) {     // Empty the file
+function fetchAll(store, category, callback){
+    store.remove(category, function(err) {     // Empty the file
         // If (err) throw err // err if the file removal failed <- commented out because it didn't exist
     })
 
     newsapi.v2.topHeadlines({
         language: 'en',
-        country: 'us'
+        country: 'us',
+        category: ((category=='all')? undefined: category)
     })
     .then(response => {
         let articleList = {
-            id: 'all',  // Adding an id to the store for when we eventually add more categories
+            id: category,  // Adding an id to the store for when we eventually add more categories
             articles: response.articles
         }
         store.add(articleList, function(err) {

--- a/lib/prep.js
+++ b/lib/prep.js
@@ -21,8 +21,8 @@ function scrape(url, callback) {
 	})
 }
 
-function prepAll(store, callback) {
-    store.load('all', function(err, articleObj) {
+function prepAll(store, category, callback) {
+    store.load(category, function(err, articleObj) {
         if (err) {
             return callback({"success" : false, "message" : "Error when reading JSON during scraping."})
         }
@@ -50,7 +50,7 @@ function prepAll(store, callback) {
 		            }
 
 		            if (completedArticles === articleList.length){
-		            	store.add({id: 'all', articles: result}, function(err) {
+		            	store.add({id: category, articles: result}, function(err) {
 				    	if (err){
 				            return callback({"success" : false, "message" : "Error storing JSON after scraping."})
 				        }

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,8 +1,8 @@
 const { MAX_ARTICLES } = require("../config.json")
 
 // Determines the top articles to give to the user
-function selectArticles(store, callback){
-    store.load('all', function(err, articleObj){
+function selectArticles(store, category, callback){
+    store.load(category, function(err, articleObj){
         if (err) {
             return callback({"success" : false, "message" : "Error when reading JSON during selecting."})
         }


### PR DESCRIPTION
# Endpoint Changes
All previous endpoints stay the same (`/all` and `/all/articles?id=`) but now they work for more categories:
`business`, `entertainment`, `general`, `health`, `science`, `sports`, `technology`